### PR TITLE
추가정보 입력 기능에 대한 단위 테스트

### DIFF
--- a/src/main/java/com/example/golfplatform/user/domain/AverageScore.java
+++ b/src/main/java/com/example/golfplatform/user/domain/AverageScore.java
@@ -1,5 +1,30 @@
 package com.example.golfplatform.user.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public enum AverageScore {
-    UNDER_72, BETWEEN_72_80, BETWEEN_81_90, BETWEEN_91_100, OVER_100
+    UNDER_72("72타 이하"), BETWEEN_72_80("72~80타"), BETWEEN_81_90("81~90타"), BETWEEN_91_100("91~100타"), OVER_100("100타 이상");
+
+    private final String description;
+
+    AverageScore(String description) {
+        this.description = description;
+    }
+
+    @JsonValue
+    public String getDescription() {
+        return description;
+    }
+
+    @JsonCreator
+    public static AverageScore from(String value) {
+        for (AverageScore score : AverageScore.values()) {
+            if (score.description.equals(value)) {
+                return score;
+            }
+        }
+        throw new IllegalArgumentException("잘못된 평균 타수입니다: " + value);
+    }
+
 }

--- a/src/main/java/com/example/golfplatform/user/domain/PreferredRegion.java
+++ b/src/main/java/com/example/golfplatform/user/domain/PreferredRegion.java
@@ -1,8 +1,36 @@
 package com.example.golfplatform.user.domain;
 
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
 
 public enum PreferredRegion {
-    GYEONGGI, GANGWON, GYEONGSANG, CHUNGCHEONG, JEOLLA, JEJU, OVERSEAS
+    GYEONGGI("경기도"),
+    GANGWON("강원도"),
+    GYEONGSANG("경상도"),
+    CHUNGCHEONG("충청도"),
+    JEOLLA("전라도"),
+    JEJU("제주도"),
+    OVERSEAS("해외");
+
+    private final String description;
+
+    PreferredRegion(String description) {
+        this.description = description;
+    }
+
+    @JsonValue
+    public String getDescription() {
+        return description;
+    }
+
+    @JsonCreator
+    public static PreferredRegion from(String value) {
+        for (PreferredRegion region : PreferredRegion.values()) {
+            if (region.description.equals(value)) {
+                return region;
+            }
+        }
+        throw new IllegalArgumentException("잘못된 지역입니다: " + value);
+    }
 }

--- a/src/test/java/com/example/golfplatform/user/UserServiceTest.java
+++ b/src/test/java/com/example/golfplatform/user/UserServiceTest.java
@@ -1,6 +1,7 @@
 package com.example.golfplatform.user;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.example.golfplatform.user.domain.AverageScore;
 import com.example.golfplatform.user.domain.PreferredRegion;
@@ -46,4 +47,46 @@ public class UserServiceTest {
         assertThat(updatedUser.isFirstLogin()).isFalse();
     }
 
+    @Test
+    @DisplayName("추가 정보 입력 실패 - 존재하지 않는 사용자")
+    void completeFirstLogin_fail_invalidUser() {
+        // given
+        Long invalidUserId = 9999L;
+        AdditionalInfoRequest request = new AdditionalInfoRequest(
+            "01012345678",
+            "test@example.com",
+            PreferredRegion.GYEONGGI,
+            AverageScore.BETWEEN_81_90
+        );
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateProfile(invalidUserId, request))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage("유저 없음");
+    }
+
+    @Test
+    @DisplayName("추가 정보 입력 실패 - 이미 입력된 사용자")
+    void completeFirstLogin_fail_alreadyCompleted() {
+        // given
+        User user = User.builder()
+            .kakaoId(123456L)
+            .email("test@example.com")
+            .nickname("testuser")
+            .isFirstLogin(false)
+            .build();
+        userRepository.save(user);
+
+        AdditionalInfoRequest request = new AdditionalInfoRequest(
+            "01012345678",
+            "test@example.com",
+            PreferredRegion.GYEONGGI,
+            AverageScore.BETWEEN_81_90
+        );
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateProfile(user.getId(), request))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage("이미 사용자 정보를 입력했습니다.");
+    }
 }

--- a/src/test/java/com/example/golfplatform/user/UserServiceTest.java
+++ b/src/test/java/com/example/golfplatform/user/UserServiceTest.java
@@ -1,0 +1,49 @@
+package com.example.golfplatform.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.golfplatform.user.domain.AverageScore;
+import com.example.golfplatform.user.domain.PreferredRegion;
+import com.example.golfplatform.user.domain.User;
+import com.example.golfplatform.user.repository.UserRepository;
+import com.example.golfplatform.user.request.AdditionalInfoRequest;
+import com.example.golfplatform.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+public class UserServiceTest {
+    @Autowired
+    private UserRepository userRepository;
+    private UserService userService;
+    @BeforeEach
+    void setup() {
+        userService = new UserService(userRepository);
+    }
+
+    @Test
+    @DisplayName("최초 로그인 사용자 추가 정보 입력 성공")
+    void addAdditionalInfo() {
+        // given
+        User user = User.builder()
+            .isFirstLogin(true)
+            .build();
+        userRepository.save(user);
+        AdditionalInfoRequest request = new AdditionalInfoRequest("01012345678",
+            "test@example.com", PreferredRegion.GYEONGSANG, AverageScore.BETWEEN_81_90);
+
+        // when
+        userService.updateProfile(user.getId(), request);
+
+        // then
+        User updatedUser = userRepository.findById(user.getId()).orElseThrow();
+        assertThat(updatedUser.getPhoneNumber()).isEqualTo("01012345678");
+        assertThat(updatedUser.getAverageScore()).isEqualTo(AverageScore.BETWEEN_81_90);
+        assertThat(updatedUser.getPreferredRegion()).isEqualTo(PreferredRegion.GYEONGSANG);
+        assertThat(updatedUser.isFirstLogin()).isFalse();
+    }
+
+}


### PR DESCRIPTION
### 🛠️ 작업 내용

---
- 추가정보 입력 기능에 대한 단위 테스트 작성
- 추가정보 입력 시 한국어로 요청 및 응답할 수 있도록 enum 클래스 수정
### 💡 참고 사항

---
- @DataJpaTest를 이용하여 단위 테스트 작성
- 기존 @SpringBootTest로 진행했었는데 이 방법은 통합테스트에서 주로 사용된다고 해서 이전에 구현했던 테스트에 대해서 고민을 해봐야함
### 🚨 현재 버그

---
x
### ☑️ Git Close

---
close #19 